### PR TITLE
Save full message paylod

### DIFF
--- a/docs/examples/extractMediaShareData.js
+++ b/docs/examples/extractMediaShareData.js
@@ -1,0 +1,172 @@
+'use strict'
+
+/**
+ * A bot that extracts data from a media_share (post).
+ * Whenever the bot receives a media_share, it extracts:
+ * - `senderIgHandle` <string> (instagram handle) of the sender of the message
+ *
+ * REMEMBER: the following data is only extracted when a media_share was send, any other message is ignored
+ * - `creatorIgHandle` <string> (instagram handle) of the creator of the shared post (NOT neccessarely the sender of the message)
+ * - `images` <array<string>> of picture urls (extracts all images if a carousel is sent)
+ * - `mediaShareUrl` <string> public link to the shared post
+ * - `timestamp` <number> unix timestamp when the media_share was posted (this is not the timestamp of the message)
+ * - `location` <object> with location information (if the post has a geotag), undefined if no geotag found
+ * - `location.coordinates` <object>{lng: Number, lat: Number} coordinates of the location where the post was taken
+ * - `location.address` <string> address of the location where the post was taken
+ * - `location.name` <string> name of the geolocation of the post
+ * - `location.shortName` <string> shortName of the geolocation of the post
+ * - `location.city` <string> city of the geolocation of the post
+ */
+
+// Import the insta.js module
+const Insta = require('@androz2091/insta.js')
+
+// Create an instance of a Instagram client
+const client = new Insta.Client()
+
+/**
+ * The connected event is vital, it means that only _after_ this will your bot start reacting to information
+ * received from Instagram
+ */
+client.on('connected', () => {
+  console.log('I am ready!')
+})
+
+// Create an event listener for all messages
+// (this eventlistener gets triggered when you either receive or send a message)
+client.on('messageCreate', message => {
+  // only process messages that
+  // - are media shares
+  // - are not send by the logged in user (only received messages, not sent messages)
+  const isMediaShare = message.data.item_type === 'media_share'
+  const isReceivedMessage = message.authorID !== client.user.id
+  if (isMediaShare && isReceivedMessage) {
+    // extract media share data
+    const extractedData = {
+      messageSender: message.author.username,
+      creatorIgHandle: extractCreator(message.data),
+      images: extractImages(message.data),
+      mediaShareUrl: extractMediaShareUrl(message.data),
+      timestamp: extractPostTimestamp(message.data),
+      location: extractLocation(message.data),
+    }
+    // display extracted metadata
+    console.log(extractedData)
+  }
+})
+
+// Log our bot in using Instagram credentials
+client.login('your instagram username', 'your instagram password')
+
+
+/*
+ * helper functions
+ */
+function extractCreator(messageData) {
+  try {
+    return messageData.media_share.user.username
+  } catch (err) {
+    console.log(err)
+    return undefined
+  }
+}
+function extractImages(messageData) {
+  let images = []
+  const postImage = extracteImageFromSinglePost(messageData)
+  if (postImage) {
+    images.push(postImage)
+  }
+  const carouselImages = extractImagesFromCarousel(messageData)
+  if (carouselImages) {
+    images = images.concat(carouselImages)
+  }
+  return images
+}
+function extractMediaShareUrl(messageData) {
+  try {
+    return `https://www.instagram.com/p/${messageData.media_share.code}`
+  } catch (err) {
+    // console.log(err)
+    return undefined
+  }
+}
+function extracteImageFromSinglePost(messageData) {
+  try {
+    return messageData.media_share.image_versions2.candidates[0].url
+  } catch (err) {
+    // console.log(err)
+    return undefined
+  }
+}
+function extractImagesFromCarousel(messageData) {
+  try {
+    return messageData.media_share.carousel_media.map(mediaObj => mediaObj.image_versions2.candidates[0].url)
+  } catch (err) {
+    // console.log(err)
+    return undefined
+  }
+}
+function extractPostTimestamp(messageData) {
+  try {
+    return messageData.media_share.taken_at
+  } catch (err) {
+    // console.log(err)
+    return undefined
+  }
+}
+function extractLocation(messageData) {
+  const location = {
+    coordinates: extractLocationCoordinates(messageData),
+    address: extractLocationAddress(messageData),
+    city: extractLocationCity(messageData),
+    name: extractLocationName(messageData),
+    shortName: extractLocationShortName(messageData),
+  }
+  if (!location.coordinates && !location.address && !location.city && !location.name && !location.shortName) {
+    return undefined
+  }
+  return location
+}
+function extractLocationCoordinates(messageData) {
+  try {
+    return {
+      lat: messageData.media_share.lat || messageData.media_share.location.lat,
+      lng: messageData.media_share.lng || messageData.media_share.location.lng,
+    }
+  } catch (err) {
+    // console.log(err)
+    return undefined
+  }
+}
+function extractLocationAddress(messageData) {
+  try {
+    return messageData.media_share.location.address
+  } catch (err) {
+    // console.log(err)
+    return undefined
+  }
+}
+function extractLocationCity(messageData) {
+  try {
+    return messageData.media_share.location.city
+  } catch (err) {
+    // console.log(err)
+    return undefined
+  }
+}
+function extractLocationName(messageData) {
+  try {
+    return messageData.media_share.location.name
+  } catch (err) {
+    // console.log(err)
+    return undefined
+  }
+}
+function extractLocationShortName(messageData) {
+  try {
+    return messageData.media_share.location.short_name
+  } catch (err) {
+    // console.log(err)
+    return undefined
+  }
+}

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -29,7 +29,10 @@ class Message {
          * @type {object}
          * The full message payload instagram is sending (forwarded by the dilame/instagram-private-api)
          */
-        this.data = data
+        Object.defineProperty(this, 'data', {
+            value: data,
+            writable: false
+        })
         /**
          * @type {string}
          * The type of the message, either:

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -26,6 +26,11 @@ class Message {
          */
         this.chatID = threadID
         /**
+         * @type {object}
+         * The full message payload instagram is sending (forwarded by the dilame/instagram-private-api)
+         */
+        this.data = data
+        /**
          * @type {string}
          * The type of the message, either:
          * * `text` - a simple message


### PR DESCRIPTION
Hey @Androz2091,

thanks a lot for this library, it's really usefull. I would love to contribute. For example it would be really usefull if the `Message` objects would not loose any information and store the whole message payload. This would make it easy to work with this library when you already know the `dilame/instagram-private-api` repo, because it is the same object.

I also added an example how to use the changes in this pull request. For example: when you send a DM to the bot of type `media_share` like this:


<img src="https://user-images.githubusercontent.com/44790691/101421518-bed8ff80-38f4-11eb-8961-8a5ec367f284.jpg" width="400" />

You get the following metadata:
```js
{
  messageSender: '...',
  creatorIgHandle: 'infatuation_london',
  images: [
    'https://scontent-ams4-1.cdninstagram.com/v/t51.2885-15/e35/p1080x1080/122424970_416215039738380_6670327433957071078_n.jpg?_nc_ht=scontent-ams4-1.cdninstagram.com&_nc_cat=100&_nc_ohc=-FjiuS3q_vYAX_grDQ-&tp=1&oh=ef64ad92eb09e7043a63ae3e60debb05&oe=5FF677F9&ig_cache_key=MjQyNzk1MzM4OTc5OTEzMzc4OA%3D%3D.2'
  ],
  mediaShareUrl: 'https://www.instagram.com/p/CGx0r6CLtJc',
  timestamp: 1603654620,
  location: {
    coordinates: { lat: 51.48765183, lng: -0.16903313884126 },
    address: '151 Sydney St',
    city: 'London, United Kingdom',
    name: 'Phat Phuc Noodle Bar',
    shortName: 'Phat Phuc Noodle Bar'
  }
}
```

Let me know if you would like to see that as a function on the message object. For example I thought these two methods could be added:
- `Message.isMediaShare()`: returns true if the message is a media share. 
- `Message.extractMediaShareData()`: returns an object with extracted metadata of a media_share (as demoed in my extractMediaShareMetadata.js)

Let me know if you think that is valuable and if you want me to continue :) 



