### PR TITLE
Update Message.js to catch hidden story share case

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -65,9 +65,16 @@ class Message {
          */
         this.storyShareData = undefined
         if (data.item_type === 'story_share') {
-            this.storyShareData = {
-                author: data.story_share.message === 'No longer available' ? null : this.client._patchOrCreateUser(data.story_share.media.user.pk, data.story_share.media.user),
-                sourceURL: data.story_share.message === 'No longer available' ? null : data.story_share.media.image_versions2.candidates[0].url
+            if (data.story_share.message === 'No longer available' || data.story_share.message.startsWith("This story is hidden because")) {
+                this.storyShareData = {
+                    author: null,
+                    sourceURL: null
+                }
+            } else {
+                this.storyShareData = {
+                    author: this.client._patchOrCreateUser(data.story_share.media.user.pk, data.story_share.media.user),
+                    sourceURL: data.story_share.media.image_versions2.candidates[0].url
+                }
             }
         }
         /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -65,7 +65,8 @@ class Message {
          */
         this.storyShareData = undefined
         if (data.item_type === 'story_share') {
-            if (data.story_share.message === 'No longer available' || data.story_share.message.startsWith("This story is hidden because")) {
+            const msg = data.story_share.message
+            if (msg === undefined || msg === 'No longer available' || msg.startsWith("This story is hidden because")) {
                 this.storyShareData = {
                     author: null,
                     sourceURL: null


### PR DESCRIPTION
This pull request solves issue #45. 

It catches the case of a story share that is hidden. The message data in this case looks like this:
![Bildschirmfoto vom 2021-01-19 13-53-36](https://user-images.githubusercontent.com/44790691/105040330-001b0e00-5a62-11eb-8fa5-da50e1551bf1.png)

We could also extract the handle of the story that was hidden from the message string and save it in the `this.storyShare.author` variable. I am open for suggestions.  

@Androz2091 Let me know what you think of this.