### PR TITLE
Get item_id after voice upload

### DIFF
--- a/src/structures/Chat.js
+++ b/src/structures/Chat.js
@@ -242,7 +242,8 @@ class Chat {
      */
     sendVoice (buffer) {
         return new Promise((resolve) => {
-            this.threadEntity.broadcastVoice({ file: buffer }).then(({ item_id: itemID }) => {
+            this.threadEntity.broadcastVoice({ file: buffer }).then((upload) => {
+                let itemID = upload.message_metadata[0].item_id
                 if (this.typing && !this._disableTypingOnSend) this._keepTypingAlive()
                 this._sentMessagesPromises.set(itemID, resolve)
                 if (this.messages.has(itemID)) {


### PR DESCRIPTION
Hello there! First of all, thanks for this amazing library.

From my tests, it seems that the response after voice upload is coming in this format:

```
{
  message_metadata: [
    {
      thread_id: '<thread_id>',
      item_id: '<item_id>',
      participant_ids: [Array],
      timestamp: '1612822714120679',
      client_context: 'aac90301-da47-53e4-a232-f75590976508'
    }
  ],
  upload_id: '1612822710696',
  status: 'ok'
}
```

Maybe this is something particular to the account I'm using, or maybe it requires more checks than just reading the first element of `message_metadata` - the intent of this pull request is just to raise the discussion.

Thanks!